### PR TITLE
Make resultSet compatible with upstream

### DIFF
--- a/Model/Datasource/Database/PostgresNoMeta.php
+++ b/Model/Datasource/Database/PostgresNoMeta.php
@@ -20,7 +20,7 @@ class PostgresNoMeta extends \Postgres
      * @see fetchResult
      * @override
      */
-    public function resultSet(&$results)
+    public function resultSet($results)
     {
         # Deliberately don't do anything in here
     }

--- a/Model/Datasource/Database/PostgresNoMeta.php
+++ b/Model/Datasource/Database/PostgresNoMeta.php
@@ -16,7 +16,7 @@ class PostgresNoMeta extends \Postgres
      *
      * This avoid calling getColumnMeta which is expensive in Postgres
      *
-     * @param array $results
+     * @param PDOStatement $results
      * @see fetchResult
      * @override
      */


### PR DESCRIPTION
As part of CakePHP 2.10.12 (see release notes here: https://github.com/cakephp/cakephp/releases/tag/2.10.12) and https://github.com/cakephp/cakephp/pull/12506, @bancer changed the signature of `resultSet` within https://github.com/cakephp/cakephp/commit/2aa8fac574a52a26272f5458adf80584c384db91. 

This was the warning I received after upgrade to CakePHP 2.10.12:

```
Warning: Declaration of PostgresNoMeta::resultSet(&$results) should be compatible with Postgres::resultSet($results) in /vagrant/app.swat.io/app/Plugin/PostgresNoMeta/Model/Datasource/Database/PostgresNoMeta.php on line 11
```

For your fork, which is used inside our app, we need to change this too. 

Would love to see this being merged to master. And it would also be great if you could create a new release, so we can update our composer dependencies.

Thanks!