### PR TITLE
Override lastInsertId to return an int when is_numeric

### DIFF
--- a/Model/Datasource/Database/PostgresNoMeta.php
+++ b/Model/Datasource/Database/PostgresNoMeta.php
@@ -78,4 +78,17 @@ class PostgresNoMeta extends \Postgres
 
         return 'E' . str_replace('\\', '\\\\', $value);
     }
+
+    /**
+     * Converts the ID to int if it is_numeric
+     *
+     * @inheritdoc
+     * @return int|string
+     */
+    public function lastInsertId($source = null, $field = 'id')
+    {
+        $id = parent::lastInsertId($source, $field);
+
+        return is_numeric($id) ? (int) $id : $id;
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# CakePHP2 - Postgres driver without getColumnMeta and special escaping support
+# CakePHP2 - Postgres driver with custom adaptions
 
-This driver was changed in two ways:
+This driver was changed in the following ways:
 
 1) The default CakePHP 2.x Postgres driver uses `getColumnMeta` to infer
 column types from the server. Although the PHP part has been optimized
@@ -16,6 +16,10 @@ underlying PDO/PgSQL driver [4].
 
 The method `\Postgres::value()` was overriden to apply the special C-style
 escape operation to strings [5].
+
+3) The default PHP/PDO `lastInsertId` always returns a string. This driver is
+adapted to return an integer if `is_numeric` returns true on it. This allows
+easier integration with codebases using `strict_types=1`.
 
 # Requirements and Installation
 


### PR DESCRIPTION
The (CakePHP2) drivers `lastInsertId` returns the native result of [PDO::lastInsertId](http://php.net/manual/en/pdo.lastinsertid.php) which is always a `string`.

This can be a problem if you want to use `strict_types=1` in your codebase.

Other projects like [Laravel check for `is_numeric` and simply convert it](https://github.com/laravel/framework/pull/418). This is exactly the same approach.

This has been tested with an internal project and everything seems to work. Just a few tests performing strict comparison against the string have to be adapted.