### PR TITLE
Don't escape special CURRENT_TIMESTAMP construct

### DIFF
--- a/Model/Datasource/Database/PostgresNoMeta.php
+++ b/Model/Datasource/Database/PostgresNoMeta.php
@@ -69,6 +69,12 @@ class PostgresNoMeta extends \Postgres
         if (!isset($value{0})) {
             return $value;
         }
+
+        # This special construct doesn't require further escaping and would break otherwise
+        if ($value === "'CURRENT_TIMESTAMP'") {
+            return $value;
+        }
+
         # If it starts with a single quote we assume it also ends with one
         # and thus directly jump to the conclusion we can use our
         # special postgres escape method

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ easier integration with codebases using `strict_types=1`.
 
 1. You need at least CakePHP 2.10.12<br>
    For CakePHP >= 2.0 and < 2.10.12 , you can use version `0.0.2` of this package
-1. Add the line `"mfn/cakephp2-postgres-no-meta": "^0.0.4"` to your `app/composer.json`
+1. Add the line `"mfn/cakephp2-postgres-no-meta": "^0.0.5"` to your `app/composer.json`
 2. Run `php composer.phar require mfn/cakephp2-postgres-no-meta`
 3. Load the plugin in `app/Config/bootstrap.php` with the line
 ```php

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "mfn/cakephp2-postgres-no-meta",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "type": "cakephp-plugin",
     "description": "A CakePHP2 Postgres database driver without getColumnMeta() support",
     "keywords": ["CakePHP", "Postgres", "Database"],


### PR DESCRIPTION
Otherwise it will get converted to `E'CURRENT_TIMESTAMP'` which by
itself is an invalid syntax.

This is part of the reason why the CakePHP2 based test suite broke on my system. Certain tables were generated with `TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL` which results in above problem.

The other part is that we've multiple DDL dialects creating the same kind of tables, one uses above syntax and others use `… DEFAULT now() …` which does not trigger this. The reason for multiple dialects has to do with SQL to create tables from DDL dumps from production vs. the ones from application migration. The one which works (i.e. uses `now()`) is the production DDL dump, the migration uses `CURRENT_TIMESTAMP` and can break it.

Pretty sure in the past both worked, can't say what changed since then. It's not related to PHP 7.3 vs. 7.4 though.